### PR TITLE
Exclude cli/ from site tsconfig include

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,6 +45,7 @@
   "exclude": [
     "out/**/*",
     "node_modules",
+    "cli",
     "archive/**/*",
     "src/tests/**/*",
     "app/(default)/alignair/.archive_page",


### PR DESCRIPTION
## Summary

`next build` (Pages deploy workflow) is failing in CI on `main`:

```
./cli/src/commands/mcp.ts:51:38
Type error: Cannot find module '@modelcontextprotocol/sdk/server/mcp.js' or its corresponding type declarations.
```

This is independent of #13 — that PR didn't touch the site tsconfig or `cli/src/commands/mcp.ts`. It's a pre-existing bug that #13 didn't surface because #13 only verified the `cli/` build, not the site build.

## Root cause

`tsconfig.json` `include` has `"**/*.ts"` with no `cli` exclusion, so Next.js's type-check phase pulls `cli/src/commands/mcp.ts` into the program. That file does:

```ts
const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
```

TypeScript resolves module names for dynamic `import()` the same as static imports (it needs the type of the resolved namespace). `@modelcontextprotocol/sdk` is in `cli/package.json` but **not** in the site root's `package.json`, and the Pages CI workflow only runs `npm ci` at the repo root.

## Fix

One-line: add `"cli"` to the site tsconfig `exclude`:

```diff
   "exclude": [
     "out/**/*",
     "node_modules",
+    "cli",
     "archive/**/*",
     ...
```

`"cli"` (no glob) matches the directory the same way `"node_modules"` does in the existing exclude. The cli/ sub-project already owns its own tsconfig.json, package.json, package-lock.json, and node_modules; the site has no business type-checking cli/ source, and cli/ doesn't contribute to the deployed bundle (`output: 'export'` ships only the Next.js build output).

## Why not the alternatives

- **Install `@modelcontextprotocol/sdk` at the site root.** Contaminates the site's deps with a CLI-only package and grows the deployed artifact. The architectural separation already exists.
- **TypeScript project references.** Cleaner long-term but a much bigger change.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json --listFiles | grep /cli/src/` returns no output (cli/ no longer in the site program).
- [x] `GITHUB_PAGES=true npx next build` exits 0 locally (type-check phase passes, no TS2307 on mcp.ts).
- [ ] CI: pushing this branch re-runs `Deploy Next.js site to Pages`; the build should succeed past the type-check phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)